### PR TITLE
Fix formatting error in nota_base.md

### DIFF
--- a/nota_base.md
+++ b/nota_base.md
@@ -902,7 +902,6 @@ Main agent now synthesizes the summary into a user-facing response.
    ```typescript
    const agentStatus = useEventBus<AgentStatus>('agent:status:update');
    ```
-```
 
 **What was missing from the original prompt:**
 ```


### PR DESCRIPTION
## Summary
- Removed extra triple backticks from line 905 in nota_base.md
- Fixes markdown formatting issue that was breaking the code block

## Changes
- Deleted the stray ``` on line 905 that was causing improper markdown rendering

## Test plan
- [x] Verify markdown renders correctly
- [x] Confirm code blocks display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a formatting issue in code examples (removed duplicate code fence marker).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->